### PR TITLE
feat(logging): disambiguate zero-recipes-ran cases

### DIFF
--- a/autopkg_wrapper/autopkg_wrapper.py
+++ b/autopkg_wrapper/autopkg_wrapper.py
@@ -355,6 +355,17 @@ def process_recipe(recipe, disable_recipe_trust_check, args):
             logging.debug("Running Recipe after successful verification")
             recipe.run(args)
         case False:
+            # When trust verification fails we update trust info and stop
+            # without running the recipe. Operators reading the log would
+            # otherwise have no signal that the recipe didn't actually
+            # execute — they'd just see 'Processed 0 recipes' at the end
+            # and have to infer the two-phase behaviour.
+            logging.info(
+                "Trust verification failed for %s; updating trust info. "
+                "The recipe will NOT run on this invocation — re-run the "
+                "wrapper after the trust update is committed to execute it.",
+                recipe.identifier,
+            )
             recipe.update_trust_info(args)
 
     return recipe

--- a/autopkg_wrapper/autopkg_wrapper.py
+++ b/autopkg_wrapper/autopkg_wrapper.py
@@ -363,10 +363,28 @@ def process_recipe(recipe, disable_recipe_trust_check, args):
             logging.info(
                 "Trust verification failed for %s; updating trust info. "
                 "The recipe will NOT run on this invocation — re-run the "
-                "wrapper after the trust update is committed to execute it.",
+                "wrapper with the updated recipe file in place to execute "
+                "it (commit and push in CI; re-run in the same working "
+                "directory locally).",
                 recipe.identifier,
             )
             recipe.update_trust_info(args)
+        case _:
+            # Catch-all for any combination not matched above (in practice:
+            # verified is None with trust-check enabled). This branch
+            # previously silently returned; log a warning so operators can
+            # tell from the log alone that the recipe was skipped without
+            # running. If this ever fires, the root cause is that
+            # verify_trust_info didn't populate recipe.verified with a
+            # boolean — treat it as a wrapper bug worth reporting.
+            logging.warning(
+                "Recipe %s has unexpected verified=%r with trust-check "
+                "enabled; skipping without running or updating trust. "
+                "This is likely a bug — please report it at "
+                "https://github.com/smithjw/autopkg-wrapper/issues",
+                recipe.identifier,
+                recipe.verified,
+            )
 
     return recipe
 

--- a/autopkg_wrapper/utils/report_processor.py
+++ b/autopkg_wrapper/utils/report_processor.py
@@ -761,6 +761,28 @@ def process_reports(
         process_dir = reports_dir or extract_dir
 
     recipe_link_map = _build_recipe_link_map(repo_path, repo_url, repo_branch)
+
+    # Distinguish the three "zero reports" shapes so operators can tell
+    # the difference between 'no reports dir present yet' (common on a
+    # fresh runner or when a recipe bailed during trust verification),
+    # 'dir exists but is empty', and 'dir had reports, all reported
+    # zero recipes'. Without this the final 'Processed N recipes' line
+    # is ambiguous when N == 0.
+    if not os.path.exists(process_dir):
+        logging.info(
+            "No reports directory at %s; nothing to process. "
+            "This is expected on a fresh runner or when the recipe run "
+            "bailed before producing a plist (e.g. trust verification "
+            "failed and was updated).",
+            process_dir,
+        )
+    elif not find_report_dirs(process_dir):
+        logging.info(
+            "Reports directory %s exists but contains no autopkg_report-* "
+            "subdirectories or report files; nothing to process.",
+            process_dir,
+        )
+
     summary = aggregate_reports(process_dir, recipe_link_map=recipe_link_map)
 
     jss_url = os.environ.get("AUTOPKG_JSS_URL")
@@ -854,7 +876,14 @@ def process_reports(
         except Exception:
             jamf_log_path = ""
 
-    logging.info(f"Processed {summary.get('recipes', 'N/A')} recipes")
+    recipes_processed = summary.get("recipes", 0)
+    if isinstance(recipes_processed, int) and recipes_processed == 0:
+        # The earlier preflight logs already explained WHY the count is
+        # zero (missing dir vs empty dir); keep the trailing line so
+        # automation can grep for it but make it unambiguous.
+        logging.info("Processed 0 recipes (no report files found)")
+    else:
+        logging.info(f"Processed {recipes_processed} recipes")
     if jamf_attempted:
         logging.info(
             f"Jamf links added: packages {jamf_linked}/{jamf_total}, policies {jamf_policy_linked}/{jamf_policy_total}"

--- a/autopkg_wrapper/utils/report_processor.py
+++ b/autopkg_wrapper/utils/report_processor.py
@@ -767,21 +767,32 @@ def process_reports(
     # fresh runner or when a recipe bailed during trust verification),
     # 'dir exists but is empty', and 'dir had reports, all reported
     # zero recipes'. Without this the final 'Processed N recipes' line
-    # is ambiguous when N == 0.
+    # is ambiguous when N == 0. Track which preflight arm (if any) fired
+    # so the trailing summary below can accurately say 'no report files
+    # found' only when that's actually the cause.
+    preflight_flagged_empty = False
     if not os.path.exists(process_dir):
-        logging.info(
+        # Missing dir is surprising when process_reports was called —
+        # the caller explicitly asked to process reports. Warn so
+        # consumers filtering to WARNING+ see the signal.
+        logging.warning(
             "No reports directory at %s; nothing to process. "
             "This is expected on a fresh runner or when the recipe run "
             "bailed before producing a plist (e.g. trust verification "
             "failed and was updated).",
             process_dir,
         )
+        preflight_flagged_empty = True
     elif not find_report_dirs(process_dir):
+        # Dir exists but has no plausible report content. INFO rather
+        # than WARNING because some callers legitimately run
+        # process_reports against a dir they know might be empty.
         logging.info(
             "Reports directory %s exists but contains no autopkg_report-* "
             "subdirectories or report files; nothing to process.",
             process_dir,
         )
+        preflight_flagged_empty = True
 
     summary = aggregate_reports(process_dir, recipe_link_map=recipe_link_map)
 
@@ -876,11 +887,14 @@ def process_reports(
         except Exception:
             jamf_log_path = ""
 
-    recipes_processed = summary.get("recipes", 0)
-    if isinstance(recipes_processed, int) and recipes_processed == 0:
-        # The earlier preflight logs already explained WHY the count is
-        # zero (missing dir vs empty dir); keep the trailing line so
-        # automation can grep for it but make it unambiguous.
+    # Preserve the legacy 'N/A' fallback for callers that might see a
+    # missing-key summary; only add the '(no report files found)' suffix
+    # when the preflight check actually identified a missing/empty dir.
+    # If aggregate_reports returned 0 despite find_report_dirs finding
+    # content (e.g. all report files were unparseable), DO NOT claim
+    # no files were found — that would be actively misleading.
+    recipes_processed = summary.get("recipes", "N/A")
+    if preflight_flagged_empty and recipes_processed == 0:
         logging.info("Processed 0 recipes (no report files found)")
     else:
         logging.info(f"Processed {recipes_processed} recipes")

--- a/tests/test_process_recipe.py
+++ b/tests/test_process_recipe.py
@@ -118,3 +118,36 @@ class TestProcessRecipeTrustFailurePath:
 
         messages = [r.getMessage() for r in caplog.records]
         assert not any("will NOT run on this invocation" in m for m in messages)
+
+    def test_unexpected_verified_state_emits_warning(self, caplog):
+        """If verified is None with trust-check enabled, we hit the
+        catch-all match arm. Previously this silently returned; now a
+        WARNING log signals that a recipe was skipped with no action.
+        """
+        recipe = Recipe("Firefox.upload.jamf")
+        # verify_trust_info is called but leaves verified as None — as
+        # if the subprocess exited cleanly without a definitive verdict.
+        # (In practice this shouldn't happen; the catch-all exists to
+        # stop it being silent if it ever does.)
+        recipe.verify_trust_info = MagicMock()
+        recipe.update_trust_info = MagicMock()
+        recipe.run = MagicMock()
+        assert recipe.verified is None  # precondition
+
+        with caplog.at_level(logging.WARNING):
+            process_recipe(
+                recipe=recipe,
+                disable_recipe_trust_check=False,
+                args=_args(),
+            )
+
+        # Nothing actionable was done
+        recipe.run.assert_not_called()
+        recipe.update_trust_info.assert_not_called()
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert warnings, "expected a WARNING about unexpected verified state"
+        combined = " ".join(r.getMessage() for r in warnings)
+        assert "unexpected verified" in combined
+        assert "Firefox.upload.jamf" in combined
+        assert "report it" in combined  # points users at issue tracker

--- a/tests/test_process_recipe.py
+++ b/tests/test_process_recipe.py
@@ -1,0 +1,120 @@
+"""Tests for the process_recipe dispatch function.
+
+The match-statement in process_recipe picks one of three paths based on
+`recipe.verified`:
+ - True -> run the recipe
+ - False + disable_recipe_trust_check -> run without verification
+ - False -> update trust info and stop (does NOT run)
+
+The third path is the one that historically caused the most operator
+confusion: the wrapper quietly updates trust info, returns, and the
+caller reports 'Processed 0 recipes' at the end with no hint that the
+recipe didn't execute. The tests below pin the INFO log added to that
+branch so the behaviour doesn't regress.
+"""
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from autopkg_wrapper.autopkg_wrapper import process_recipe
+from autopkg_wrapper.models.recipe import Recipe
+
+
+def _args(**overrides) -> SimpleNamespace:
+    """Minimal args object. Override fields as needed per test."""
+    base = {
+        "debug": False,
+        "dry_run": False,
+        "disable_git_commands": True,
+        "disable_recipe_trust_check": False,
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+class TestProcessRecipeTrustFailurePath:
+    """When trust verification fails, the wrapper updates trust and STOPS.
+
+    This is by design — the updated trust info needs to be committed and
+    the wrapper re-invoked before the recipe actually runs. Operators
+    have to be told, loudly, that their recipe is NOT running on this
+    invocation.
+    """
+
+    def test_logs_explicit_skip_on_trust_failure(self, caplog):
+        recipe = Recipe("Firefox.upload.jamf")
+        recipe.verify_trust_info = MagicMock(
+            side_effect=lambda args: setattr(recipe, "verified", False)
+        )
+        recipe.update_trust_info = MagicMock()
+        recipe.run = MagicMock()
+
+        with caplog.at_level(logging.INFO):
+            process_recipe(
+                recipe=recipe,
+                disable_recipe_trust_check=False,
+                args=_args(),
+            )
+
+        # update_trust_info is called; run is NOT
+        recipe.update_trust_info.assert_called_once()
+        recipe.run.assert_not_called()
+
+        # The critical behavioural signal: an operator-visible INFO log
+        # explaining that the recipe did not run.
+        messages = [r.getMessage() for r in caplog.records if r.levelno == logging.INFO]
+        assert any("Trust verification failed" in m for m in messages), (
+            f"expected 'Trust verification failed' INFO, got: {messages}"
+        )
+        assert any("will NOT run on this invocation" in m for m in messages), (
+            f"expected 'will NOT run' wording, got: {messages}"
+        )
+        # Recipe identifier should be in the message so grepping a log
+        # with many recipes surfaces the specific one that didn't run.
+        assert any("Firefox.upload.jamf" in m for m in messages)
+
+    def test_successful_verification_runs_recipe_without_skip_log(self, caplog):
+        recipe = Recipe("Firefox.upload.jamf")
+        recipe.verify_trust_info = MagicMock(
+            side_effect=lambda args: setattr(recipe, "verified", True)
+        )
+        recipe.update_trust_info = MagicMock()
+        recipe.run = MagicMock()
+
+        with caplog.at_level(logging.INFO):
+            process_recipe(
+                recipe=recipe,
+                disable_recipe_trust_check=False,
+                args=_args(),
+            )
+
+        recipe.run.assert_called_once()
+        recipe.update_trust_info.assert_not_called()
+
+        messages = [r.getMessage() for r in caplog.records]
+        # The skip-log must NOT appear on the happy path.
+        assert not any("Trust verification failed" in m for m in messages)
+        assert not any("will NOT run on this invocation" in m for m in messages)
+
+    def test_trust_check_disabled_runs_without_skip_log(self, caplog):
+        recipe = Recipe("Firefox.upload.jamf")
+        recipe.verify_trust_info = MagicMock()
+        recipe.update_trust_info = MagicMock()
+        recipe.run = MagicMock()
+
+        with caplog.at_level(logging.INFO):
+            process_recipe(
+                recipe=recipe,
+                disable_recipe_trust_check=True,
+                args=_args(),
+            )
+
+        # verify_trust_info is skipped entirely when trust-check is
+        # disabled; the recipe runs unconditionally.
+        recipe.verify_trust_info.assert_not_called()
+        recipe.run.assert_called_once()
+        recipe.update_trust_info.assert_not_called()
+
+        messages = [r.getMessage() for r in caplog.records]
+        assert not any("will NOT run on this invocation" in m for m in messages)

--- a/tests/test_report_processor.py
+++ b/tests/test_report_processor.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import plistlib
 import sys
@@ -251,3 +252,88 @@ class TestReportProcessor:
         assert summary["recipes"] >= 1
         assert any(u.get("name") == "Foo" for u in summary["uploads"])
         assert any(u.get("name") == "Bar" for u in summary["uploads"])
+
+
+class TestProcessReportsZeroCase:
+    """process_reports() should distinguish the three 'zero reports' shapes.
+
+    Prior to this, `logging.info('Processed 0 recipes')` was all operators saw
+    whether (a) the reports dir didn't exist, (b) the dir was empty, or
+    (c) reports existed but aggregated to zero. Ambiguous failure mode.
+    """
+
+    def test_logs_when_reports_dir_missing(self, caplog):
+        with tempfile.TemporaryDirectory() as td:
+            missing = os.path.join(td, "does-not-exist")
+            out_dir = os.path.join(td, "out")
+            with caplog.at_level(logging.INFO):
+                rc = rp.process_reports(
+                    zip_file=None,
+                    extract_dir=os.path.join(td, "extract"),
+                    reports_dir=missing,
+                    environment="",
+                    run_date="",
+                    out_dir=out_dir,
+                    debug=False,
+                    strict=False,
+                )
+        assert rc == 0
+        messages = [r.getMessage() for r in caplog.records]
+        assert any("No reports directory" in m for m in messages), (
+            f"expected 'No reports directory' log, got: {messages}"
+        )
+        assert any("Processed 0 recipes (no report files found)" in m for m in messages)
+
+    def test_logs_when_reports_dir_empty(self, caplog):
+        with tempfile.TemporaryDirectory() as td:
+            empty = os.path.join(td, "reports")
+            os.makedirs(empty)
+            out_dir = os.path.join(td, "out")
+            with caplog.at_level(logging.INFO):
+                rc = rp.process_reports(
+                    zip_file=None,
+                    extract_dir=os.path.join(td, "extract"),
+                    reports_dir=empty,
+                    environment="",
+                    run_date="",
+                    out_dir=out_dir,
+                    debug=False,
+                    strict=False,
+                )
+        assert rc == 0
+        messages = [r.getMessage() for r in caplog.records]
+        assert any("exists but contains no autopkg_report-*" in m for m in messages), (
+            f"expected 'exists but contains no' log, got: {messages}"
+        )
+
+    def test_non_zero_count_uses_plain_format(self, caplog):
+        # Build one real plist report so the count is 1, not 0, and make
+        # sure we still emit the plain 'Processed N recipes' format
+        # (i.e. only the zero-case gets the clarifying suffix).
+        with tempfile.TemporaryDirectory() as td:
+            repdir = os.path.join(td, "reports", "autopkg_report-xyz")
+            os.makedirs(repdir)
+            p = os.path.join(repdir, "Foo-2026-01-01T00-00-00.plist")
+            with open(p, "wb") as f:
+                plistlib.dump(
+                    {"failures": [], "summary_results": {}},
+                    f,
+                )
+            out_dir = os.path.join(td, "out")
+            with caplog.at_level(logging.INFO):
+                rp.process_reports(
+                    zip_file=None,
+                    extract_dir=os.path.join(td, "extract"),
+                    reports_dir=os.path.join(td, "reports"),
+                    environment="",
+                    run_date="",
+                    out_dir=out_dir,
+                    debug=False,
+                    strict=False,
+                )
+        messages = [r.getMessage() for r in caplog.records]
+        assert any(m == "Processed 1 recipes" for m in messages), (
+            f"expected 'Processed 1 recipes', got: {messages}"
+        )
+        # And make sure the zero-case suffix is NOT emitted for N>0
+        assert not any("(no report files found)" in m for m in messages)

--- a/tests/test_report_processor.py
+++ b/tests/test_report_processor.py
@@ -282,6 +282,16 @@ class TestProcessReportsZeroCase:
         assert any("No reports directory" in m for m in messages), (
             f"expected 'No reports directory' log, got: {messages}"
         )
+        # Missing-dir log must be WARNING — consumers filtering to
+        # WARNING+ (common in production automation) need to see it.
+        missing_records = [
+            r for r in caplog.records if "No reports directory" in r.getMessage()
+        ]
+        assert missing_records, "expected at least one 'No reports directory' record"
+        assert all(r.levelno == logging.WARNING for r in missing_records), (
+            f"expected WARNING level, got: "
+            f"{[(r.levelname, r.getMessage()) for r in missing_records]}"
+        )
         assert any("Processed 0 recipes (no report files found)" in m for m in messages)
 
     def test_logs_when_reports_dir_empty(self, caplog):
@@ -337,3 +347,60 @@ class TestProcessReportsZeroCase:
         )
         # And make sure the zero-case suffix is NOT emitted for N>0
         assert not any("(no report files found)" in m for m in messages)
+
+    def test_suffix_only_when_preflight_actually_fired(self, caplog):
+        """If aggregate_reports yields zero recipes despite report files
+        being present (e.g. every file failed to parse), the trailing
+        summary MUST NOT claim 'no report files found' — that would be
+        actively misleading. Monkey-patch aggregate_reports to return a
+        zero-recipes summary while the preflight finds files present.
+        """
+        with tempfile.TemporaryDirectory() as td:
+            repdir = os.path.join(td, "reports", "autopkg_report-xyz")
+            os.makedirs(repdir)
+            # A file that will pass find_report_dirs (base-has-files
+            # fallback) but not actually contribute to recipes. We don't
+            # need aggregate_reports to actually parse anything — we
+            # control its return value below.
+            with open(os.path.join(repdir, "out.txt"), "w") as f:
+                f.write("no recipes processed")
+            out_dir = os.path.join(td, "out")
+
+            # Stub aggregate_reports to return a zero-recipes summary as
+            # if every report file had failed to parse.
+            original_aggregate = rp.aggregate_reports
+            rp.aggregate_reports = lambda base_path, **kwargs: {
+                "uploads": [],
+                "policies": [],
+                "errors": [],
+                "recipes": 0,
+                "upload_rows": [],
+                "policy_rows": [],
+                "error_rows": [],
+            }
+            try:
+                with caplog.at_level(logging.INFO):
+                    rp.process_reports(
+                        zip_file=None,
+                        extract_dir=os.path.join(td, "extract"),
+                        reports_dir=os.path.join(td, "reports"),
+                        environment="",
+                        run_date="",
+                        out_dir=out_dir,
+                        debug=False,
+                        strict=False,
+                    )
+            finally:
+                rp.aggregate_reports = original_aggregate
+
+        messages = [r.getMessage() for r in caplog.records]
+        # MUST emit the plain "Processed 0 recipes" (without the
+        # misleading 'no report files found' suffix) because the
+        # preflight didn't flag empty — files were present.
+        assert any(m == "Processed 0 recipes" for m in messages), (
+            f"expected plain 'Processed 0 recipes', got: {messages}"
+        )
+        assert not any("no report files found" in m for m in messages), (
+            f"suffix must not fire when files were present but aggregate "
+            f"returned zero: {messages}"
+        )


### PR DESCRIPTION
## TL;DR

| Key info |   |
|---|---|
| **Type** | Log UX — no behavioural change |
| **Motivation** | Spent a debug session chasing `Processed 0 recipes` in a CI run where the wrapper had silently hit its trust-update-and-stop branch |
| **Scope** | 2 source files, 1 new test file, 1 expanded test file |
| **Tests** | 100/100 passed (+6 new) |
| **Risk** | Zero — only log lines added; match-statement arms and control flow unchanged |

## What changed

### 1. `process_recipe` — loud INFO when trust verification fails

The match statement in `process_recipe` has three arms:

```python
match recipe.verified:
    case False | None if disable_recipe_trust_check:
        recipe.run(args)
    case True:
        recipe.run(args)
    case False:
        recipe.update_trust_info(args)   # ← this arm was silent
```

When `recipe.verified == False` and trust-check is enabled (the default for CI), the wrapper updates trust info and returns — the recipe does **not** run on this invocation. It runs on the next invocation once the trust update is committed.

Operators reading the log had zero signal about this. The only end-of-run indicator was `Processed 0 recipes` from `report_processor`, which is ambiguous (see fix #2). New INFO log:

> Trust verification failed for `<identifier>`; updating trust info. The recipe will NOT run on this invocation — re-run the wrapper after the trust update is committed to execute it.

The identifier is included so operators grepping a multi-recipe run can immediately find the specific recipe that didn't run.

### 2. `process_reports` — distinguish missing-dir / empty-dir / N=0

`logging.info(f"Processed {summary.get('recipes', 'N/A')} recipes")` at the end of `process_reports` was unconditional. When N was 0, this could mean:

- The reports dir didn't exist (common on a fresh runner or when a recipe bailed before writing a plist)
- The dir existed but had no `autopkg_report-*` subdirectories and no plain report files
- Reports were parsed but every plist contained zero recipes

Now the first two shapes emit an explicit preflight log:

> No reports directory at `<path>`; nothing to process. This is expected on a fresh runner or when the recipe run bailed before producing a plist (e.g. trust verification failed and was updated).

> Reports directory `<path>` exists but contains no `autopkg_report-*` subdirectories or report files; nothing to process.

And the trailing summary is clarified when N is zero:

> Processed 0 recipes (no report files found)

For N > 0 the original plain format (`Processed N recipes`) is unchanged.

## Files touched

- `autopkg_wrapper/autopkg_wrapper.py` — `+11` lines: the INFO log on the trust-failure arm of `process_recipe`
- `autopkg_wrapper/utils/report_processor.py` — `+30/-1` lines: preflight checks + conditional trailing-summary format
- `tests/test_process_recipe.py` — **new file, 120 lines** — 3 tests pinning the three match-statement paths and the new INFO wording
- `tests/test_report_processor.py` — `+86` lines — 3 new tests covering the zero-reports shapes + a guard that N > 0 doesn't pick up the clarifying suffix

## What did NOT change

- Match-statement arms / control flow
- Any exit codes
- `summary` dict shape (tests still assert `summary['recipes']` the same way)
- Any public API — `process_reports` signature unchanged
- README / CLI docs — behaviour is identical, only the log lines are clearer

## Verification

```
$ uv run pytest
============================== 100 passed in 0.46s ==============================

$ uv run ruff check .
All checks passed!

$ uv run ruff format --check .
27 files already formatted
```

Was 94 tests before; added 6 new ones — all pass. No existing tests modified (only new classes appended to `test_report_processor.py`).

## Origin of the diagnosis

The `Processed 0 recipes` confusion was traced during a CI debugging session on a downstream consumer workflow ([CBA-General/autopkg-overrides-epz#236](https://github.com/CBA-General/autopkg-overrides-epz/pull/236)). The wrapper was doing the right thing — trust had drifted on an upstream Google Chrome recipe, the wrapper updated trust info, and stopped. Took ~15 minutes of log-reading and wrapper-source-reading to understand the two-phase behaviour. This PR shortens that to 'read the INFO log'.