### PR TITLE
feat(logging): quiet 'Skipping git updates' log on no-op runs

### DIFF
--- a/autopkg_wrapper/autopkg_wrapper.py
+++ b/autopkg_wrapper/autopkg_wrapper.py
@@ -208,6 +208,23 @@ def update_recipe_repo(recipe, git_info, disable_recipe_trust_check, args):
             return
 
 
+def _needs_git_updates(recipe_list) -> bool:
+    """Whether any recipe in the batch has state the git-update pass would act on.
+
+    A recipe triggers git work if either:
+      * recipe.updated is True  — the recipe produced committable changes
+      * recipe.verified is False — trust verification failed and
+        process_recipe took the update_trust_info arm, leaving a
+        modified recipe file to commit
+
+    If neither holds for any recipe in the batch, the 'Skipping git
+    updates' / 'Dry run: skipping git updates' log line is misleading:
+    there would have been nothing to do even with git enabled. Callers
+    use this predicate to downgrade that log to DEBUG on no-op runs.
+    """
+    return any(r.updated is True or r.verified is False for r in recipe_list)
+
+
 def parse_recipe_list(recipes, recipe_file, post_processors, args):
     """Parse recipe inputs into a common list of recipe names.
 
@@ -610,11 +627,25 @@ def main():
                     if r.error or r.results.get("failed"):
                         failed_recipes.append(r)
 
-    # Apply git updates serially to avoid branch/commit conflicts when concurrency > 1
+    # Apply git updates serially to avoid branch/commit conflicts when
+    # concurrency > 1.
+    #
+    # Avoid emitting the 'Skipping git updates' / 'Dry run: skipping git
+    # updates' INFO line on runs where every recipe ran cleanly and the
+    # git-update pass would have had literally nothing to do. Historic
+    # behaviour logged the skip unconditionally, which confused
+    # operators investigating why a CI pipeline produced no commits
+    # (it was correct, there was just nothing to skip).
     if args.dry_run:
-        logging.info("Dry run: skipping git updates")
+        if _needs_git_updates(recipe_list):
+            logging.info("Dry run: skipping git updates")
+        else:
+            logging.debug("Dry run: no git updates needed")
     elif args.disable_git_commands:
-        logging.info("Skipping git updates (disabled)")
+        if _needs_git_updates(recipe_list):
+            logging.info("Skipping git updates (disabled)")
+        else:
+            logging.debug("No git updates required; --disable-git-commands is a no-op")
     else:
         if override_repo_info is None:
             override_repo_info = get_override_repo_info(args)

--- a/tests/test_needs_git_updates.py
+++ b/tests/test_needs_git_updates.py
@@ -1,0 +1,75 @@
+"""Tests for the _needs_git_updates helper.
+
+Pin the predicate that gates whether the 'Skipping git updates (disabled)'
+log fires. A clean run — every recipe ran successfully, no trust updates,
+no committable changes — must register as "nothing to do" so we don't
+emit a misleading skip-log.
+"""
+
+from autopkg_wrapper.autopkg_wrapper import _needs_git_updates
+from autopkg_wrapper.models.recipe import Recipe
+
+
+def _clean_recipe(identifier: str = "Test.upload.jamf") -> Recipe:
+    """A freshly-initialised recipe — defaults match a clean run."""
+    return Recipe(identifier)
+
+
+class TestNeedsGitUpdates:
+    def test_empty_list_does_not_need_updates(self) -> None:
+        # Degenerate case: no recipes at all.
+        assert _needs_git_updates([]) is False
+
+    def test_all_clean_recipes_do_not_need_updates(self) -> None:
+        # Every recipe's defaults: updated=False, verified=None.
+        # This is the "everything ran cleanly" state — the point of
+        # the helper is that it returns False here so the skip-log
+        # is downgraded to DEBUG.
+        recipes = [_clean_recipe(f"Test{i}.upload.jamf") for i in range(3)]
+        assert _needs_git_updates(recipes) is False
+
+    def test_recipe_with_updated_true_needs_updates(self) -> None:
+        r = _clean_recipe()
+        r.updated = True
+        assert _needs_git_updates([r]) is True
+
+    def test_recipe_with_verified_false_needs_updates(self) -> None:
+        # verified=False is the signal that trust verification failed
+        # and process_recipe went down the update_trust_info arm —
+        # there's a modified recipe file to commit.
+        r = _clean_recipe()
+        r.verified = False
+        assert _needs_git_updates([r]) is True
+
+    def test_verified_true_alone_does_not_need_updates(self) -> None:
+        # Recipe ran successfully after trust verification passed;
+        # nothing for the git-update pass to do.
+        r = _clean_recipe()
+        r.verified = True
+        assert _needs_git_updates([r]) is False
+
+    def test_verified_none_alone_does_not_need_updates(self) -> None:
+        # process_recipe wasn't called or bailed before setting verified.
+        # Treat as "no git work" — if the caller needed git work
+        # they'd have set updated=True explicitly.
+        r = _clean_recipe()
+        assert r.verified is None  # precondition
+        assert _needs_git_updates([r]) is False
+
+    def test_one_dirty_recipe_flips_whole_batch(self) -> None:
+        # Mixed batch: 2 clean + 1 with a failed trust check.
+        # Should return True because the batch as a whole needs work.
+        clean_a = _clean_recipe("A.upload.jamf")
+        dirty = _clean_recipe("B.upload.jamf")
+        dirty.verified = False
+        clean_c = _clean_recipe("C.upload.jamf")
+        assert _needs_git_updates([clean_a, dirty, clean_c]) is True
+
+    def test_both_flags_set_needs_updates(self) -> None:
+        # Defensive: updated=True AND verified=False are not exclusive
+        # in principle. Either alone is enough; both together still
+        # means work.
+        r = _clean_recipe()
+        r.updated = True
+        r.verified = False
+        assert _needs_git_updates([r]) is True


### PR DESCRIPTION
## TL;DR

| Key info |   |
|---|---|
| **Type** | Log UX — no behavioural change |
| **Scope** | 1 source file, 1 new test file |
| **Tests** | 110/110 pass (+8 new) |
| **Trigger** | Operator confusion: CI pipeline showed 'Skipping git updates (disabled)' on every run regardless of whether any recipe had trust-update-work, making it look like a commit was being suppressed when there was simply nothing to commit |

## What changed

When every recipe in a batch runs cleanly — trust verified first try, no committable changes produced — there's literally no work for the git-update pass to do. Previously the wrapper logged at INFO level regardless:

```
autopkg_wrapper.py - main - INFO: Skipping git updates (disabled)
```

This fires on every `--disable-git-commands` run (e.g. every CI invocation), whether or not any recipe had trust-update state worth committing. Operators looking at "why didn't this run ship a commit?" were led to believe the wrapper had *chosen* to skip a real git operation, when in fact there was nothing to skip.

Same pattern on `--dry-run`:

```
INFO: Dry run: skipping git updates
```

## Change

New module-level helper:

```python
def _needs_git_updates(recipe_list) -> bool:
    return any(r.updated is True or r.verified is False for r in recipe_list)
```

Gate both INFO logs on this predicate. When `False` (all recipes clean), drop to DEBUG with clarifying wording:

```
DEBUG: No git updates required; --disable-git-commands is a no-op
```

The `updated-or-trust-failed` signal is already the codebase's canonical "this recipe produced git-relevant state" predicate — it's used at line 648 to pick a representative recipe for PR creation. The helper just extracts and names it.

## What did NOT change

- Control flow: the `if args.dry_run / elif args.disable_git_commands / else` branches are unchanged, same steps run in the same order
- INFO signal on runs where git-work IS skipped: those still emit the original message
- DEBUG verbosity: nothing new surfaces at the default INFO level on clean runs (quieter, not noisier)
- Public API, CLI flags, test coverage on other paths

## Tests

`tests/test_needs_git_updates.py` (new): 8 cases pinning the predicate contract:
- Empty list → False
- All-clean batch → False (the point of the fix)
- One recipe with `updated=True` → True
- One recipe with `verified=False` → True (trust failure path)
- Recipe with `verified=True` alone → False
- Recipe with `verified=None` alone → False (init state)
- Mixed batch with one dirty → True (one flips the whole batch)
- Both flags set → True (defensive; flags aren't exclusive)

## Verification

```
$ uv run pytest
============================= 110 passed in 0.28s ==============================

$ uv run ruff check .
All checks passed!

$ uv run ruff format --check .
28 files already formatted
```

## Origin

Flagged by a downstream consumer using the wrapper in CI on the EPZ (Engineering Productivity Zone) autopkg pipeline. A scheduled run produced no commits (correct — nothing changed), but the operator had to read the wrapper source to confirm the 'skipping' log wasn't hiding a bug.